### PR TITLE
feat: make CIA bid card manager configurable with fallback

### DIFF
--- a/ai-agents/agents/cia/potential_bid_card_integration.py
+++ b/ai-agents/agents/cia/potential_bid_card_integration.py
@@ -1,238 +1,347 @@
-"""
-CIA Integration with Potential Bid Cards API
-This module handles creating and updating potential bid cards during CIA conversations
-"""
+"""Utilities for managing Potential Bid Cards during CIA conversations."""
 
+from __future__ import annotations
+
+import asyncio
 import logging
-import json
+import uuid
+from typing import Any, Dict, Optional
+
 import httpx
-from typing import Dict, Any, Optional
-from datetime import datetime
+
+from config.service_urls import ServiceEndpoints
 
 logger = logging.getLogger(__name__)
 
+
+class _InMemoryPotentialBidCardStore:
+    """Simple in-memory store used as a fallback when HTTP service is unavailable."""
+
+    def __init__(self) -> None:
+        self._cards: Dict[str, Dict[str, Any]] = {}
+        self._lock = asyncio.Lock()
+
+    async def create(self, payload: Dict[str, Any]) -> str:
+        async with self._lock:
+            bid_card_id = str(uuid.uuid4())
+            self._cards[bid_card_id] = {
+                "id": bid_card_id,
+                "conversation_id": payload.get("conversation_id"),
+                "session_id": payload.get("session_id"),
+                "user_id": payload.get("user_id"),
+                "anonymous_user_id": payload.get("anonymous_user_id"),
+                "title": payload.get("title", "New Project"),
+                "fields": {},
+                "status": "pending",
+                "completion_percentage": 0,
+            }
+            return bid_card_id
+
+    async def update_field(
+        self,
+        bid_card_id: str,
+        field_name: str,
+        field_value: Any,
+        confidence: float,
+    ) -> bool:
+        async with self._lock:
+            card = self._cards.get(bid_card_id)
+            if not card:
+                return False
+
+            fields = card.setdefault("fields", {})
+            fields[field_name] = {
+                "value": field_value,
+                "confidence": confidence,
+            }
+
+            non_empty = len([f for f in fields.values() if f["value"] not in (None, "")])
+            card["completion_percentage"] = min(non_empty * 10, 100)
+            return True
+
+    async def get_status(self, bid_card_id: str) -> Optional[Dict[str, Any]]:
+        async with self._lock:
+            card = self._cards.get(bid_card_id)
+            if not card:
+                return None
+            return {
+                "id": card["id"],
+                "status": card.get("status", "pending"),
+                "completion_percentage": card.get("completion_percentage", 0),
+                "fields": {name: info["value"] for name, info in card.get("fields", {}).items()},
+            }
+
+    async def convert(self, bid_card_id: str, payload: Dict[str, Any]) -> Optional[str]:
+        async with self._lock:
+            card = self._cards.get(bid_card_id)
+            if not card:
+                return None
+            official_id = payload.get("official_bid_card_id") or str(uuid.uuid4())
+            card["official_bid_card_id"] = official_id
+            card["status"] = "converted"
+            return official_id
+
+
 class PotentialBidCardManager:
-    """Manages potential bid card creation and updates during CIA conversations"""
-    
-    def __init__(self, base_url: str = "http://localhost:8008"):
-        self.base_url = base_url
-        self.api_endpoint = f"{base_url}/api/cia/potential-bid-cards"
-        
+    """Manages potential bid card creation and updates during CIA conversations."""
+
+    FIELD_MAPPING: Dict[str, str] = {
+        # Core project fields (FIXED)
+        "project_type": "project_type",
+        "project_description": "description",
+        "title": "title",
+
+        # Location fields (FIXED)
+        "location_zip": "location_zip",
+        "zip_code": "zip_code",
+        "zip": "zip_code",
+        "room_location": "room_location",
+        "property_area": "property_area",
+
+        # Budget fields (FIXED)
+        "budget_min": "budget_min",
+        "budget_max": "budget_max",
+        "budget_context": "budget_context",
+
+        # Timeline fields
+        "timeline": "estimated_timeline",
+        "urgency": "urgency_level",
+        "timeline_flexibility": "timeline_flexibility",
+
+        # Contractor preferences
+        "contractor_size": "contractor_size_preference",
+        "quality_expectations": "quality_expectations",
+
+        # Materials and specifications
+        "materials": "materials_specified",
+        "special_requirements": "special_requirements",
+
+        # Service and complexity
+        "service_type": "service_type",
+        "project_complexity": "project_complexity",
+        "component_type": "component_type",
+        "service_complexity": "service_complexity",
+        "trade_count": "trade_count",
+        "primary_trade": "primary_trade",
+        "secondary_trades": "secondary_trades",
+
+        # Date fields
+        "bid_collection_deadline": "bid_collection_deadline",
+        "project_completion_deadline": "project_completion_deadline",
+        "deadline_hard": "deadline_hard",
+        "deadline_context": "deadline_context",
+
+        # Email/contact
+        "email_address": "email_address",
+    }
+
+    IGNORED_FIELDS = {
+        "property_type",
+        "property_size",
+        "current_condition",
+        "location",
+        "location_context",
+        "contractor_requirements",
+        "urgency_reason",
+        "timeline_details",
+        "uploaded_photos",
+        "photo_analyses",
+        "phone_number",
+    }
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        client: Optional[httpx.AsyncClient] = None,
+        use_fallback: bool = False,
+        fallback_store: Optional[_InMemoryPotentialBidCardStore] = None,
+    ) -> None:
+        api_base = base_url or ServiceEndpoints.CIA_POTENTIAL_BID_CARDS
+        self.api_endpoint = api_base.rstrip("/")
+        self._client = client
+        self._fallback = fallback_store if use_fallback else None
+        if use_fallback and self._fallback is None:
+            self._fallback = _InMemoryPotentialBidCardStore()
+
     async def create_potential_bid_card(
-        self, 
+        self,
         conversation_id: str,
         session_id: str,
-        user_id: Optional[str] = None
+        user_id: Optional[str] = None,
     ) -> Optional[str]:
-        """
-        Create a new potential bid card for the conversation
-        Returns the bid card ID if successful
-        """
+        """Create a new potential bid card for the conversation."""
         try:
             payload = {
                 "conversation_id": conversation_id,
                 "session_id": session_id,
                 "user_id": user_id,
                 "anonymous_user_id": user_id if user_id == "00000000-0000-0000-0000-000000000000" else None,
-                "title": "New Project"
+                "title": "New Project",
             }
-            
-            async with httpx.AsyncClient() as client:
-                response = await client.post(self.api_endpoint, json=payload)
-            
-            if response.status_code == 200:
+
+            if self._fallback:
+                bid_card_id = await self._fallback.create(payload)
+                logger.info(f"[CIA] Created potential bid card via fallback: {bid_card_id}")
+                return bid_card_id
+
+            response = await self._post(self.api_endpoint, payload)
+            if response and response.status_code == 200:
                 data = response.json()
                 bid_card_id = data.get("id")
                 logger.info(f"[CIA] Created potential bid card: {bid_card_id}")
                 return bid_card_id
-            else:
-                logger.error(f"[CIA] Failed to create potential bid card: {response.status_code}")
-                return None
-                
-        except Exception as e:
-            logger.error(f"[CIA] Error creating potential bid card: {e}")
+
+            status = response.status_code if response else "no-response"
+            logger.error(f"[CIA] Failed to create potential bid card: {status}")
             return None
-    
+
+        except Exception as exc:
+            logger.error(f"[CIA] Error creating potential bid card: {exc}")
+            return None
+
     async def update_bid_card_field(
         self,
         bid_card_id: str,
         field_name: str,
         field_value: Any,
-        confidence: float = 1.0
+        confidence: float = 1.0,
     ) -> bool:
-        """
-        Update a specific field in the potential bid card
-        """
+        """Update a specific field in the potential bid card."""
         try:
-            # Map CIA field names to potential bid card field names
-            # FIXED: These mappings now correctly match the database schema
-            field_mapping = {
-                # Core project fields (FIXED)
-                "project_type": "project_type",  # FIXED: was mapping to primary_trade
-                "project_description": "description",  # FIXED: was mapping to non-existent user_scope_notes
-                "title": "title",  # NEW: was missing
-                
-                # Location fields (FIXED)
-                "location_zip": "location_zip",  # FIXED: was missing
-                "zip_code": "zip_code",  # Keep for backward compatibility
-                "zip": "zip_code",  # Keep for backward compatibility
-                "room_location": "room_location",
-                "property_area": "property_area",
-                
-                # Budget fields (FIXED)
-                "budget_min": "budget_min",  # FIXED: was mapping to non-existent budget_range_min
-                "budget_max": "budget_max",  # FIXED: was mapping to non-existent budget_range_max
-                "budget_context": "budget_context",
-                
-                # Timeline fields
-                "timeline": "estimated_timeline",
-                "urgency": "urgency_level",
-                "timeline_flexibility": "timeline_flexibility",
-                
-                # Contractor preferences
-                "contractor_size": "contractor_size_preference",
-                "quality_expectations": "quality_expectations",
-                
-                # Materials and specifications
-                "materials": "materials_specified",
-                "special_requirements": "special_requirements",
-                
-                # Service and complexity
-                "service_type": "service_type",
-                "project_complexity": "project_complexity",
-                "component_type": "component_type",
-                "service_complexity": "service_complexity",
-                "trade_count": "trade_count",
-                "primary_trade": "primary_trade",
-                "secondary_trades": "secondary_trades",
-                
-                # Date fields
-                "bid_collection_deadline": "bid_collection_deadline",
-                "project_completion_deadline": "project_completion_deadline",
-                "deadline_hard": "deadline_hard",
-                "deadline_context": "deadline_context",
-                
-                # Email/contact
-                "email_address": "email_address"
-            }
-            
-            # Fields that don't exist in database - ignore these to avoid 500 errors
-            ignored_fields = {
-                "property_type",
-                "property_size", 
-                "current_condition",
-                "location",
-                "location_context",
-                "contractor_requirements",
-                "urgency_reason",
-                "timeline_details",
-                "uploaded_photos",
-                "photo_analyses",
-                "phone_number"
-            }
-            
-            # Skip fields that don't exist in database
-            if field_name in ignored_fields:
+            if field_name in self.IGNORED_FIELDS:
                 logger.info(f"[CIA] Skipping ignored field: {field_name}")
-                return True  # Return success to avoid blocking other updates
-            
-            # Get the mapped field name
-            mapped_field = field_mapping.get(field_name, field_name)
-            
+                return True
+
+            mapped_field = self.FIELD_MAPPING.get(field_name, field_name)
             payload = {
                 "field_name": mapped_field,
                 "field_value": field_value,
                 "confidence": confidence,
-                "source": "conversation"
+                "source": "conversation",
             }
-            
+
+            if self._fallback:
+                success = await self._fallback.update_field(bid_card_id, mapped_field, field_value, confidence)
+                if success:
+                    logger.info(f"[CIA] Updated bid card field via fallback {mapped_field}: {field_value}")
+                else:
+                    logger.error(f"[CIA] Failed to update field via fallback {mapped_field}: {bid_card_id}")
+                return success
+
             url = f"{self.api_endpoint}/{bid_card_id}/field"
-            async with httpx.AsyncClient() as client:
-                response = await client.put(url, json=payload)
-            
-            if response.status_code == 200:
+            response = await self._put(url, payload)
+
+            if response and response.status_code == 200:
                 logger.info(f"[CIA] Updated bid card field {mapped_field}: {field_value}")
                 return True
-            else:
-                logger.error(f"[CIA] Failed to update field {mapped_field}: {response.status_code}")
-                return False
-                
-        except Exception as e:
-            logger.error(f"[CIA] Error updating bid card field: {e}")
+
+            status = response.status_code if response else "no-response"
+            logger.error(f"[CIA] Failed to update field {mapped_field}: {status}")
             return False
-    
+
+        except Exception as exc:
+            logger.error(f"[CIA] Error updating bid card field: {exc}")
+            return False
+
     async def update_from_collected_info(
         self,
         bid_card_id: str,
-        collected_info: Dict[str, Any]
+        collected_info: Dict[str, Any],
     ) -> int:
-        """
-        Update multiple fields from CIA's collected_info
-        Returns number of fields successfully updated
-        """
+        """Update multiple fields from CIA's collected_info."""
         if not bid_card_id or not collected_info:
             return 0
-            
+
         updated_count = 0
-        
-        # Update each collected field
+
         for field_name, field_value in collected_info.items():
-            if field_value is not None and field_value != "":
+            if field_value not in (None, ""):
                 success = await self.update_bid_card_field(
                     bid_card_id,
                     field_name,
-                    field_value
+                    field_value,
                 )
                 if success:
                     updated_count += 1
-                    
+
         logger.info(f"[CIA] Updated {updated_count} fields in potential bid card")
         return updated_count
-    
-    async def get_bid_card_status(self, bid_card_id: str) -> Optional[Dict]:
-        """
-        Get the current status of a potential bid card
-        """
+
+    async def get_bid_card_status(self, bid_card_id: str) -> Optional[Dict[str, Any]]:
+        """Get the current status of a potential bid card."""
         try:
+            if self._fallback:
+                return await self._fallback.get_status(bid_card_id)
+
             url = f"{self.api_endpoint}/{bid_card_id}"
-            async with httpx.AsyncClient() as client:
-                response = await client.get(url)
-            
-            if response.status_code == 200:
+            response = await self._get(url)
+
+            if response and response.status_code == 200:
                 return response.json()
-            else:
-                logger.error(f"[CIA] Failed to get bid card status: {response.status_code}")
-                return None
-                
-        except Exception as e:
-            logger.error(f"[CIA] Error getting bid card status: {e}")
+
+            status = response.status_code if response else "no-response"
+            logger.error(f"[CIA] Failed to get bid card status: {status}")
             return None
-    
+
+        except Exception as exc:
+            logger.error(f"[CIA] Error getting bid card status: {exc}")
+            return None
+
     async def convert_to_official_bid_card(
         self,
         bid_card_id: str,
-        user_id: str
+        user_id: str,
     ) -> Optional[str]:
-        """
-        Convert potential bid card to official bid card after signup
-        Returns the official bid card ID if successful
-        """
+        """Convert potential bid card to official bid card after signup."""
         try:
-            url = f"{self.api_endpoint}/{bid_card_id}/convert-to-bid-card"
             payload = {"user_id": user_id}
-            
-            async with httpx.AsyncClient() as client:
-                response = await client.post(url, json=payload)
-            
-            if response.status_code == 200:
+
+            if self._fallback:
+                return await self._fallback.convert(bid_card_id, payload)
+
+            url = f"{self.api_endpoint}/{bid_card_id}/convert-to-bid-card"
+            response = await self._post(url, payload)
+
+            if response and response.status_code == 200:
                 data = response.json()
                 official_bid_card_id = data.get("official_bid_card_id")
                 logger.info(f"[CIA] Converted to official bid card: {official_bid_card_id}")
                 return official_bid_card_id
-            else:
-                logger.error(f"[CIA] Failed to convert bid card: {response.status_code}")
-                return None
-                
-        except Exception as e:
-            logger.error(f"[CIA] Error converting bid card: {e}")
+
+            status = response.status_code if response else "no-response"
+            logger.error(f"[CIA] Failed to convert bid card: {status}")
+            return None
+
+        except Exception as exc:
+            logger.error(f"[CIA] Error converting bid card: {exc}")
+            return None
+
+    async def _post(self, url: str, payload: Dict[str, Any]) -> Optional[httpx.Response]:
+        try:
+            if self._client:
+                return await self._client.post(url, json=payload)
+            async with httpx.AsyncClient() as client:
+                return await client.post(url, json=payload)
+        except Exception as exc:
+            logger.error(f"[CIA] POST request failed for {url}: {exc}")
+            return None
+
+    async def _put(self, url: str, payload: Dict[str, Any]) -> Optional[httpx.Response]:
+        try:
+            if self._client:
+                return await self._client.put(url, json=payload)
+            async with httpx.AsyncClient() as client:
+                return await client.put(url, json=payload)
+        except Exception as exc:
+            logger.error(f"[CIA] PUT request failed for {url}: {exc}")
+            return None
+
+    async def _get(self, url: str) -> Optional[httpx.Response]:
+        try:
+            if self._client:
+                return await self._client.get(url)
+            async with httpx.AsyncClient() as client:
+                return await client.get(url)
+        except Exception as exc:
+            logger.error(f"[CIA] GET request failed for {url}: {exc}")
             return None

--- a/ai-agents/config/service_urls.py
+++ b/ai-agents/config/service_urls.py
@@ -25,49 +25,51 @@ WS_URL = f"{WS_PROTOCOL}://{BACKEND_HOST}:{BACKEND_PORT}"
 # Service endpoints
 class ServiceEndpoints:
     """Centralized service endpoints for all backend services."""
-    
+
     # Base URLs
     API_BASE = f"{BACKEND_URL}/api"
     WS_BASE = f"{WS_URL}/ws"
-    
+
     # CIA Agent endpoints
     CIA_STREAM = f"{API_BASE}/cia/stream"
     CIA_CHAT = f"{API_BASE}/cia/chat"
     CIA_POTENTIAL_BID_CARDS = f"{API_BASE}/cia/potential-bid-cards"
-    
+
     # JAA Agent endpoints
     JAA_UPDATE = f"{API_BASE}/jaa/update"  # Append /{bid_card_id}
     JAA_PROCESS = f"{API_BASE}/jaa/process"
-    
+
     # COIA Agent endpoints
     COIA_CHAT = f"{API_BASE}/coia/chat"
     COIA_LANDING = f"{API_BASE}/coia/landing"
     COIA_STATE = f"{API_BASE}/coia/state"
-    
+
     # Messaging endpoints
     MESSAGING_SEND = f"{API_BASE}/messaging/send"
     MESSAGING_FILTER = f"{API_BASE}/messaging/filter"
-    
+
     # WebSocket endpoints
     WS_ADMIN = f"{WS_BASE}/admin"
     WS_AGENT_ACTIVITY = f"{WS_BASE}/agent-activity"
-    
+
     @classmethod
     def get_jaa_update_url(cls, bid_card_id: str) -> str:
         """Get the JAA update URL for a specific bid card."""
         return f"{cls.JAA_UPDATE}/{bid_card_id}"
-    
+
     @classmethod
     def get_backend_url(cls) -> str:
         """Get the base backend URL."""
         return BACKEND_URL
-    
+
     @classmethod
     def get_ws_url(cls) -> str:
         """Get the base WebSocket URL."""
         return WS_URL
 
+
 # Export for easy access
 get_backend_url = ServiceEndpoints.get_backend_url
 get_ws_url = ServiceEndpoints.get_ws_url
 get_jaa_update_url = ServiceEndpoints.get_jaa_update_url
+

--- a/ai-agents/main.py
+++ b/ai-agents/main.py
@@ -140,6 +140,7 @@ try:
     
     # Initialize CIA agent - OpenAI GPT-5 only
     from agents.cia.agent import CustomerInterfaceAgent
+    from agents.cia.potential_bid_card_integration import PotentialBidCardManager
     from routers.cia_routes_unified import set_cia_agent  # Fixed streaming endpoint enabled
     
     # Initialize JAA agent
@@ -155,7 +156,8 @@ try:
     
     if openai_api_key:
         # Use OpenAI GPT-5 exclusively
-        cia_agent = CustomerInterfaceAgent(openai_api_key)
+        potential_bid_card_manager = PotentialBidCardManager()
+        cia_agent = CustomerInterfaceAgent(openai_api_key, bid_card_manager=potential_bid_card_manager)
         set_cia_agent(cia_agent)  # Fixed streaming endpoint enabled
         logger.info("CIA agent initialized successfully with OpenAI GPT-5 API key")
     else:

--- a/ai-agents/tests/cia/test_potential_bid_card_manager.py
+++ b/ai-agents/tests/cia/test_potential_bid_card_manager.py
@@ -1,0 +1,125 @@
+import json
+import sys
+import uuid
+from pathlib import Path
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import importlib.util
+
+module_path = Path(__file__).resolve().parents[2] / "agents" / "cia" / "potential_bid_card_integration.py"
+spec = importlib.util.spec_from_file_location("potential_bid_card_integration", module_path)
+potential_bid_card_integration = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(potential_bid_card_integration)
+
+PotentialBidCardManager = potential_bid_card_integration.PotentialBidCardManager
+
+
+@pytest.mark.asyncio
+async def test_http_client_path_updates_and_status():
+    """Ensure the manager can use an injected HTTP client for all operations."""
+
+    cards = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if request.method == "POST" and path == "/api/cia/potential-bid-cards":
+            payload = json.loads(request.content.decode())
+            bid_card_id = f"http-{len(cards) + 1}"
+            cards[bid_card_id] = {
+                "payload": payload,
+                "fields": {},
+                "status": "pending",
+                "completion_percentage": 0,
+            }
+            return httpx.Response(200, json={"id": bid_card_id})
+
+        if request.method == "PUT" and path.startswith("/api/cia/potential-bid-cards/") and path.endswith("/field"):
+            bid_card_id = path.split("/")[4]
+            body = json.loads(request.content.decode())
+            cards[bid_card_id]["fields"][body["field_name"]] = body["field_value"]
+            cards[bid_card_id]["completion_percentage"] = 50
+            return httpx.Response(200, json={"success": True})
+
+        if request.method == "GET" and path.startswith("/api/cia/potential-bid-cards/"):
+            bid_card_id = path.split("/")[4]
+            card = cards[bid_card_id]
+            return httpx.Response(
+                200,
+                json={
+                    "id": bid_card_id,
+                    "status": card["status"],
+                    "completion_percentage": card["completion_percentage"],
+                    "fields": card["fields"],
+                },
+            )
+
+        if request.method == "POST" and path.endswith("/convert-to-bid-card"):
+            bid_card_id = path.split("/")[4]
+            official_id = f"official-{bid_card_id}"
+            cards[bid_card_id]["official_bid_card_id"] = official_id
+            cards[bid_card_id]["status"] = "converted"
+            return httpx.Response(200, json={"official_bid_card_id": official_id})
+
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        manager = PotentialBidCardManager(
+            base_url="http://testserver/api/cia/potential-bid-cards",
+            client=client,
+        )
+
+        bid_card_id = await manager.create_potential_bid_card(
+            conversation_id=str(uuid.uuid4()),
+            session_id="session-123",
+            user_id="user-456",
+        )
+        assert bid_card_id in cards
+
+        updated = await manager.update_bid_card_field(bid_card_id, "title", "Test Project", confidence=0.8)
+        assert updated is True
+
+        status = await manager.get_bid_card_status(bid_card_id)
+        assert status is not None
+        assert status["id"] == bid_card_id
+        assert status["fields"]["title"] == "Test Project"
+
+        official_id = await manager.convert_to_official_bid_card(bid_card_id, "user-456")
+        assert official_id == f"official-{bid_card_id}"
+        assert cards[bid_card_id]["status"] == "converted"
+
+
+@pytest.mark.asyncio
+async def test_in_memory_fallback_operations():
+    """The fallback store should allow tests to run without HTTP services."""
+
+    manager = PotentialBidCardManager(use_fallback=True)
+
+    bid_card_id = await manager.create_potential_bid_card(
+        conversation_id="conv-1",
+        session_id="session-1",
+        user_id=None,
+    )
+    assert bid_card_id is not None
+
+    await manager.update_bid_card_field(bid_card_id, "project_description", "A backyard remodel")
+    await manager.update_from_collected_info(
+        bid_card_id,
+        {"budget_min": 1000, "budget_max": 5000, "zip_code": "94107"},
+    )
+
+    status = await manager.get_bid_card_status(bid_card_id)
+    assert status is not None
+    assert status["fields"]["description"] == "A backyard remodel"
+    assert status["fields"]["budget_min"] == 1000
+    assert status["fields"]["zip_code"] == "94107"
+
+    official_id = await manager.convert_to_official_bid_card(bid_card_id, "user-789")
+    assert official_id is not None
+    assert official_id != ""


### PR DESCRIPTION
## Summary
- update the CIA potential bid card manager to accept injected HTTP clients or fall back to an in-memory store while using centralized service URLs
- allow the customer interface agent and FastAPI bootstrap to pass configured managers and surface bid-card creation failures in responses
- add pytest coverage for both the HTTP-backed path and the fallback store to ensure bid card ids and statuses propagate correctly

## Testing
- pytest ai-agents/tests/cia/test_potential_bid_card_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68ca503899c4832fa94423781888749b