### PR TITLE
Initialize license tool and add web fallback search

### DIFF
--- a/ai-agents/agents/coia/tools/__init__.py
+++ b/ai-agents/agents/coia/tools/__init__.py
@@ -7,6 +7,7 @@ import logging
 from typing import Dict, Any, Optional, List
 
 from .google_api.places import GooglePlacesTool
+from .google_api.licenses import LicenseSearchTool
 from .web_research.tavily import TavilySearchTool
 from .database.contractors import ContractorDatabaseTool
 from .database.bid_cards import BidCardSearchTool
@@ -27,6 +28,7 @@ class COIATools(BaseTool):
         
         # Initialize all specialized tools
         self.google_places = GooglePlacesTool()
+        self.license_search = LicenseSearchTool()
         self.tavily_search = TavilySearchTool()
         self.contractor_db = ContractorDatabaseTool()
         self.bid_card_search = BidCardSearchTool()
@@ -145,4 +147,4 @@ class COIATools(BaseTool):
 
 
 # Export the main class
-__all__ = ['COIATools']
+__all__ = ["COIATools"]

--- a/ai-agents/agents/coia/tools/google_api/places.py
+++ b/ai-agents/agents/coia/tools/google_api/places.py
@@ -5,7 +5,11 @@ Handles Google Places API searches for business information
 
 import logging
 import os
-from typing import Dict, Any, Optional
+import re
+from html import unescape
+from typing import Dict, Any, Optional, List
+from urllib.parse import parse_qs, quote_plus, unquote, urlparse
+
 import httpx
 
 from ..base import BaseTool
@@ -88,37 +92,133 @@ class GooglePlacesTool(BaseTool):
         
         # Fallback to web scraping if Google API fails or not available
         logger.info(f"Falling back to web search for: {company_name}")
+        query = company_name
+        if location:
+            query = f"{company_name} {location}"
+
         try:
-            query = company_name
-            if location:
-                query = f"{company_name} {location}"
             
             business_data = await self._search_business_web(query)
-            
+
             if business_data:
                 logger.info(f"Found business data via web search: {company_name}")
                 return business_data
-            else:
-                logger.info(f"No web results found for {query}")
-                return self._create_minimal_business_data(company_name, location)
-                
+
+            logger.info(f"No web results found for {query}")
+            return self._create_minimal_business_data(company_name, location, query)
+
         except Exception as e:
             logger.error(f"Error with fallback web search: {e}")
-            return self._create_minimal_business_data(company_name, location)
-    
-    async def _search_business_web(self, query: str) -> Optional[Dict[str, Any]]:
-        """
-        Fallback web search method - placeholder for now
-        TODO: Implement actual web search fallback
-        """
-        logger.info(f"Web search fallback not fully implemented for: {query}")
-        return None
-    
-    def _create_minimal_business_data(self, company_name: str, location: Optional[str]) -> Dict[str, Any]:
+            return self._create_minimal_business_data(company_name, location, query)
+
+    async def _search_business_web(self, query: str, max_results: int = 5) -> Optional[Dict[str, Any]]:
+        """Use DuckDuckGo Lite as a lightweight web fallback when Google is unavailable."""
+        logger.info(f"Attempting DuckDuckGo Lite fallback search for: {query}")
+
+        encoded_query = quote_plus(query)
+        url = f"https://lite.duckduckgo.com/lite/?q={encoded_query}"
+
+        headers = {
+            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
+        }
+
+        async with httpx.AsyncClient(timeout=30.0, headers=headers) as client:
+            response = await client.get(url)
+
+        if response.status_code != 200:
+            logger.warning(
+                "DuckDuckGo Lite request failed with status %s", response.status_code
+            )
+            return None
+
+        html_content = response.text
+
+        link_pattern = re.compile(
+            r"<a[^>]*href=\"(?P<href>[^\"]+)\"[^>]*class='result-link'>(?P<title>.*?)</a>",
+            re.IGNORECASE | re.DOTALL,
+        )
+        snippet_pattern = re.compile(
+            r"<td class='result-snippet'>(?P<snippet>.*?)</td>", re.IGNORECASE | re.DOTALL
+        )
+
+        results: List[Dict[str, Any]] = []
+
+        for match in link_pattern.finditer(html_content):
+            raw_url = match.group("href")
+            normalized_url = self._extract_duckduckgo_target(raw_url)
+
+            # Skip sponsored entries or items without a resolvable target URL
+            if not normalized_url or "duckduckgo.com" in normalized_url:
+                continue
+
+            snippet_match = snippet_pattern.search(html_content, match.end())
+            snippet_text = (
+                self._clean_html(snippet_match.group("snippet")) if snippet_match else ""
+            )
+
+            title = self._clean_html(match.group("title"))
+
+            results.append(
+                {
+                    "title": title,
+                    "url": normalized_url,
+                    "snippet": snippet_text,
+                }
+            )
+
+            if len(results) >= max_results:
+                break
+
+        if not results:
+            return None
+
+        top_result = results[0]
+        return {
+            "company_name": top_result["title"],
+            "website": top_result["url"],
+            "summary": top_result["snippet"],
+            "search_results": results,
+            "search_query": query,
+            "data_source": "duckduckgo_web_fallback",
+        }
+
+    @staticmethod
+    def _clean_html(value: str) -> str:
+        """Remove HTML tags and decode entities from a snippet."""
+        text = re.sub(r"<[^>]+>", " ", value)
+        text = unescape(text)
+        return " ".join(text.split())
+
+    @staticmethod
+    def _extract_duckduckgo_target(raw_url: str) -> str:
+        """Extract the ultimate URL from a DuckDuckGo redirect link."""
+        if raw_url.startswith("//"):
+            raw_url = f"https:{raw_url}"
+
+        try:
+            parsed = urlparse(raw_url)
+        except ValueError:
+            return raw_url
+
+        if "duckduckgo.com" not in parsed.netloc:
+            return raw_url
+
+        query_params = parse_qs(parsed.query)
+        target = query_params.get("uddg")
+        if not target:
+            return raw_url
+
+        return unquote(target[0])
+
+    def _create_minimal_business_data(
+        self, company_name: str, location: Optional[str], query: Optional[str] = None
+    ) -> Dict[str, Any]:
         """Create minimal business data when API fails"""
         return {
             "company_name": company_name,
             "location": location,
+            "search_query": query,
             "data_source": "manual_entry",
             "verified": False
         }


### PR DESCRIPTION
## Summary
- instantiate the license search tool inside `COIATools` so the exposed coroutine can execute without raising an `AttributeError`
- add a DuckDuckGo Lite-based fallback path in `GooglePlacesTool` with HTML cleanup, redirect handling, and sponsored-link filtering to populate minimal business data when the Google API is unavailable

## Testing
- pytest ai-agents/tests/coia/test_direct_search.py *(fails: async coroutine in test lacks a plugin marker)*

------
https://chatgpt.com/codex/tasks/task_e_68ca50ee12d8832fa840229396f41850